### PR TITLE
Changed Docker image build to use d-m-p internal config

### DIFF
--- a/.maven-dockerignore
+++ b/.maven-dockerignore
@@ -1,1 +1,0 @@
-target/docker/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM openjdk:8-alpine
-
-ADD target/age-checker-service-swarm.jar /age-checker-service-swarm.jar
-
-WORKDIR /
-EXPOSE 8080
-
-CMD ["java", "-jar", "age-checker-service-swarm.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,51 @@
               <images>
                 <image>
                   <name>arquillian/age-checker:${project.version}</name>
+                  <alias>age-checker</alias>
                   <build>
-                    <dockerFileDir>${project.basedir}</dockerFileDir>
+                    <!-- FROM -->
+                    <from>openjdk:8-alpine</from>
+
+                    <!-- ADD -->
+                    <assembly>
+                      <!-- By default the assembly goes below '/maven' in the image but can be changed
+                           with base dir -->
+                      <basedir>/</basedir>
+                      <!-- Assembly Descriptor inlined. Could be also in an external file and then
+                           referenced via "<descriptor>"
+
+                           The next version of d-m-p will include a predefined descriptor
+                           "widlfly-swarm" so it will become even shorter.
+                           Track https://github.com/fabric8io/docker-maven-plugin/issues/584 for details.
+                           -->
+                      <inline>
+                        <files>
+                          <file>
+                            <source>${project.build.directory}/age-checker-service-swarm.jar</source>
+                          </file>
+                        </files>
+                      </inline>
+                    </assembly>
+
+                    <!-- WORKDIR -->
+                    <workdir>/</workdir>
+                    <!-- EXPOSE -->
+                    <ports>
+                      <port>8080</port>
+                    </ports>
+                    <!-- CMD -->
+                    <cmd>
+                      <exec>
+                        <arg>java</arg>
+                        <arg>-jar</arg>
+                        <arg>age-checker-service-swarm.jar</arg>
+                      </exec>
+                    </cmd>
+                    <!-- Alternative, this could be used which uses the shell execution format :
+                    <cmd>
+                      <shell>java -jar age-checker-service-swarm.jar</shell>
+                    </cmd>
+                    -->
                   </build>
                 </image>
               </images>


### PR DESCRIPTION
Please find some notes as comments in pom.xml. This version has the
adavantage over the Dockerfile variant, that is can build faster as
the Docker build context doesn't contain the whole source
directory. It might not be a problem here because the project is
small, but can become one if there a lot more stoff in the project
directory which should not be included in the image but will be send
to the Docker daemon nevertheless.

You can test this with

```
mvn -Pdocker docker:build docker:run -Ddocker.follow
```
